### PR TITLE
resolved WGS-QC circos.R chrom NaN error for SHAH-3563

### DIFF
--- a/wgs_qc_utils/reader/read_remixt.py
+++ b/wgs_qc_utils/reader/read_remixt.py
@@ -6,6 +6,7 @@ def read(remixt):
     cnv_data = pd.read_csv(remixt, sep="\t")
 
     cnv_data["total_raw_e"] = cnv_data.major_raw_e + cnv_data.minor_raw_e
+    cnv_data["chromosome"] = cnv_data.chromosome.astype(str) # object -> str
     cnv_data["chromosome"] = cnv_data.chromosome.str.lower()
     cnv_data.rename(columns={"chromosome":"chrom"}, inplace=True)
     

--- a/wgs_qc_utils/reader/read_remixt.py
+++ b/wgs_qc_utils/reader/read_remixt.py
@@ -3,10 +3,9 @@ import os
 import yaml
 
 def read(remixt):
-    cnv_data = pd.read_csv(remixt, sep="\t")
+    cnv_data = pd.read_csv(remixt, sep="\t", converters={'chromosome': str})
 
     cnv_data["total_raw_e"] = cnv_data.major_raw_e + cnv_data.minor_raw_e
-    cnv_data["chromosome"] = cnv_data.chromosome.astype(str) # object -> str
     cnv_data["chromosome"] = cnv_data.chromosome.str.lower()
     cnv_data.rename(columns={"chromosome":"chrom"}, inplace=True)
     


### PR DESCRIPTION
Resolved WGS QC 0.0.1 fail error at circos.R ([SHAH-3563](https://molonc.atlassian.net/browse/SHAH-3563))
Example of previously failed runs - isabl pks: 
- [23721](https://isabl.shahlab.mskcc.org/?project=46&analysis=23721) 
- [23720](https://isabl.shahlab.mskcc.org/?project=46&analysis=23720) 
- [23719](https://isabl.shahlab.mskcc.org/?project=46&analysis=23719) 
- [23718](https://isabl.shahlab.mskcc.org/?project=46&analysis=23718) 
- [23691](https://isabl.shahlab.mskcc.org/?project=46&analysis=23691)
