### PR TITLE
Bug fix: ROH plot in genomewide plot is full of false-positive ROH events

### DIFF
--- a/wgs_qc_utils/reader/read_remixt.py
+++ b/wgs_qc_utils/reader/read_remixt.py
@@ -6,6 +6,7 @@ def read(remixt):
     cnv_data = pd.read_csv(remixt, sep="\t")
 
     cnv_data["total_raw_e"] = cnv_data.major_raw_e + cnv_data.minor_raw_e
+    cnv_data["chromosome"] = cnv_data.chromosome.astype(str) # object -> str
     cnv_data["chromosome"] = cnv_data.chromosome.str.lower()
     cnv_data.rename(columns={"chromosome":"chrom"}, inplace=True)
     

--- a/wgs_qc_utils/reader/read_remixt.py
+++ b/wgs_qc_utils/reader/read_remixt.py
@@ -3,10 +3,9 @@ import os
 import yaml
 
 def read(remixt):
-    cnv_data = pd.read_csv(remixt, sep="\t")
+    cnv_data = pd.read_csv(remixt, sep="\t", converters={'chromosome': str})
 
     cnv_data["total_raw_e"] = cnv_data.major_raw_e + cnv_data.minor_raw_e
-    cnv_data["chromosome"] = cnv_data.chromosome.astype(str) # object -> str
     cnv_data["chromosome"] = cnv_data.chromosome.str.lower()
     cnv_data.rename(columns={"chromosome":"chrom"}, inplace=True)
     

--- a/wgs_qc_utils/reader/read_roh.py
+++ b/wgs_qc_utils/reader/read_roh.py
@@ -8,9 +8,6 @@ class EmptyRohReader():
         self.state = None
 
 
-
-
-
 def read(file):
     """
     read in roh data to pandas df
@@ -18,12 +15,19 @@ def read(file):
     :return: pandas dataframe
     """
     if file.endswith(".gz"):
-        data = pd.read_csv(file, usecols=["type","sample","chromosome","start","state","quality"])
+        data = pd.read_csv(
+            file, 
+            usecols=["type","sample","chromosome","start","state","quality"],
+            converters={
+                'chromosome': str,
+            }
+        )
     else:
         data = _parse_old_roh_format(file)
     if data.empty:
         return EmptyRohReader()
     data = data.rename(columns={"chromosome": "chrom", "quality":"qual"})
+    data = data[~data.state.isna()]
     data = data.astype({"chrom":str})
     data["chrom"] = data.chrom.str.lower()
     


### PR DESCRIPTION
In the `roh_calling` process of the `samtool_germline` task uses `bcftools roh` to create an ROH output saved as csv.
Here, `parse_roh_output` is used to save the output csv into a parsed csv.gz output, where it introduces `float('nan')` in the 'state' column of the csv.gz output file if the 'type' column == 'RG' (not if it is =='ST'). 
I don't know why the RG type line is saved in the csv.gz file, but this certainly is the cause of NA values saved in the 'state' column of the _roh.csv.gz output.
Anyways, such NA values from the 'RG'-starting lines could be removed by the bug fix I commited.
